### PR TITLE
docs: remove completed TODO items and reference issue #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,9 @@ When creating issues, please follow our simple naming convention:
 - Keep under 60 characters
 - No period at the end
 
-## TODO
+## Development
 
-- [ ] **Unit Tests**: Comprehensive test coverage for core functionality
-- [ ] **UI Tests**: Automated UI testing for user interactions
+For planned improvements and testing infrastructure, see [issue #9](https://github.com/renjfk/SimplyTrack/issues/9).
 
 ## License
 


### PR DESCRIPTION
Remove completed TODO items from README since they are now tracked in dedicated issues.

## Changes

- Remove "Unit Tests" and "UI Tests" items from TODO section
- Replace TODO section with "Development" section that references issue #9
- Keep README clean and current

Closes #11