### PR TITLE
build: implement manual release process with GitHub MCP integration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,26 @@
 name: Build and Release
 
 on:
-  push:
-    tags:
-      - 'v*'  # Triggers on version tags like v1.0.0, v1.1.0, etc.
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag (e.g., v1.0.0)'
+        required: true
+        type: string
+      release_notes:
+        description: 'Release notes content (markdown supported)'
+        required: true
+        type: string
+      prerelease:
+        description: 'Mark as pre-release'
+        required: false
+        type: boolean
+        default: false
+      draft:
+        description: 'Create as draft release'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -24,42 +41,45 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Need full history for release notes
+          fetch-depth: 0
 
-      - name: Set version from tag
+      - name: Create and push release tag
+        run: |
+          RELEASE_TAG="${{ github.event.inputs.release_tag }}"
+          
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          # Create tag if it doesn't exist
+          if ! git rev-parse "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Creating new tag: $RELEASE_TAG"
+            git tag -a "$RELEASE_TAG" -m "Release $RELEASE_TAG"
+            git push origin "$RELEASE_TAG"
+          else
+            echo "Tag $RELEASE_TAG already exists"
+          fi
+
+      - name: Extract version from tag
         id: version
         run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
+          RELEASE_TAG="${{ github.event.inputs.release_tag }}"
+          VERSION=${RELEASE_TAG#v}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Setting version to: $VERSION"
 
-      - name: Generate Release Notes
+      - name: Save release notes
         id: release_notes
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          
-          # Get commits since last tag
-          LAST_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-          
-          if [ -z "$LAST_TAG" ]; then
-            # First release - get all commits
-            COMMITS=$(git log --pretty=format:"* %s ([%h](https://github.com/${{ github.repository }}/commit/%H))" --no-merges)
-          else
-            # Get commits since last tag
-            COMMITS=$(git log $LAST_TAG..HEAD --pretty=format:"* %s ([%h](https://github.com/${{ github.repository }}/commit/%H))" --no-merges)
-          fi
-          
-          # Create simple release notes with linked commit hashes
-          cat << EOF > release_notes.md
-          ## Changes
-          
-          $COMMITS
+          # Save the provided release notes
+          cat << 'EOF' > release_notes.md
+          ${{ github.event.inputs.release_notes }}
           EOF
           
           # Set output for next jobs
-          echo "release_notes<<EOF" >> $GITHUB_OUTPUT
+          echo "release_notes<<NOTES_EOF" >> $GITHUB_OUTPUT
           cat release_notes.md >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "NOTES_EOF" >> $GITHUB_OUTPUT
 
       - name: Upload release notes artifact
         uses: actions/upload-artifact@v4
@@ -361,12 +381,13 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: ${{ github.event.inputs.release_tag }}
           files: |
             build/SimplyTrack.dmg
             build/SimplyTrack.dmg.sha256
           body_path: release_notes.md
-          draft: false
-          prerelease: false
-          generate_release_notes: true
+          draft: ${{ github.event.inputs.draft }}
+          prerelease: ${{ github.event.inputs.prerelease }}
+          generate_release_notes: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/MCP_RELEASE_EXAMPLE.md
+++ b/MCP_RELEASE_EXAMPLE.md
@@ -1,0 +1,253 @@
+# MCP Release Process Example
+
+This document shows an example of how the MCP-driven release process works in practice with Claude Desktop.
+
+## Example Session: Creating Release v1.2.0
+
+### User Input (Claude Desktop)
+```
+I need to create a new release for SimplyTrack. Please use GitHub MCP to:
+
+STEP 1: ANALYZE COMMITS
+- Get the latest release tag from the repository
+- Fetch all commits between that tag and current HEAD
+- Analyze each commit for user-facing changes
+
+STEP 2: GENERATE RELEASE NOTES
+Create structured release notes with this EXACT format:
+
+## SimplyTrack v[VERSION]
+
+### ⚠️ Breaking Changes
+[Only if breaking changes exist]
+* Description focusing on user impact ([abc1234](commit-link))
+
+### ✨ New Features
+* Feature description emphasizing user benefit ([abc1234](commit-link))
+
+### 🚀 Improvements  
+* Improvement description with user impact ([abc1234](commit-link))
+
+### 🐛 Bug Fixes
+* Fix description focusing on resolved user issue ([abc1234](commit-link))
+
+---
+**Release Type**: [major/minor/patch]
+**Commits**: [count] 
+**Generated**: [timestamp]
+
+REQUIREMENTS:
+- Focus ONLY on user-facing changes and impact
+- EXCLUDE: docs, build, ci, chore, refactor, test commits  
+- Use active voice, present tense
+- Include working GitHub commit links
+- Determine semantic version based on changes
+- Show this preview BEFORE any actions
+
+STEP 3: SHOW PREVIEW
+Display the generated release notes and ask for approval before proceeding.
+
+STEP 4: TRIGGER WORKFLOW (after approval)
+Use GitHub MCP to trigger the "Build and Release" workflow with:
+- release_tag: v[VERSION]  
+- release_notes: [generated content]
+- draft: true
+- prerelease: false (unless specified)
+
+Please start with Step 1 - analyze the commits and show me the preview.
+```
+
+### Expected Claude Response
+
+```
+I'll help you create a new release for SimplyTrack using GitHub MCP. Let me start by analyzing the commits since the last release.
+
+**STEP 1: ANALYZING COMMITS**
+
+🔍 Getting latest release tag...
+Latest release: v1.1 (released 2024-08-15)
+
+🔍 Fetching commits between v1.1 and HEAD...
+Found 12 commits to analyze
+
+**STEP 2: GENERATING RELEASE NOTES**
+
+After analyzing the commits, I've categorized the user-facing changes:
+
+📋 **RELEASE NOTES PREVIEW:**
+
+## SimplyTrack v1.2
+
+### ✨ New Features
+* Added dark mode support with automatic system preference detection (b29ffaf)
+* Implemented export to CSV functionality for time tracking data (bd32f00)  
+* Added keyboard shortcuts for common actions (⌘N, ⌘E, ⌘S) (ab5b664)
+
+### 🚀 Improvements
+* Improved app startup time by 40% through optimized data loading (d24b0ad)
+* Enhanced memory usage efficiency for large datasets (f72d4cb)
+* Streamlined preferences interface with better organization (a1c2d3e)
+
+### 🐛 Bug Fixes
+* Fixed crash when opening app on macOS Sonoma (e4f5g6h)
+* Resolved timezone display issues in time reports (i7j8k9l)
+* Fixed memory leak in background time tracking (m0n1p2q)
+
+---
+**Release Type**: minor
+**Commits**: 12
+**Generated**: 2024-09-07 15:30:00 UTC
+
+**STEP 3: PREVIEW CONFIRMATION**
+
+✅ **Analysis Summary:**
+- **New Features**: 3 (dark mode, CSV export, keyboard shortcuts)
+- **Improvements**: 3 (performance and UX enhancements)  
+- **Bug Fixes**: 3 (crash fixes and memory issues)
+- **Excluded**: 3 commits (docs updates, test changes, CI improvements)
+- **Suggested Version**: v1.2 (minor release due to new features)
+
+**Does this look correct? Should I proceed to trigger the release workflow with these parameters?**
+
+- release_tag: `v1.2`
+- release_notes: [the content above]
+- draft: `true`
+- prerelease: `false`
+
+Please confirm to proceed with **STEP 4: TRIGGER WORKFLOW**.
+```
+
+### User Confirmation
+```
+Yes, this looks perfect! Please proceed to trigger the workflow.
+```
+
+### Final Claude Response
+
+```
+**STEP 4: TRIGGERING WORKFLOW**
+
+🚀 Dispatching GitHub Actions workflow...
+
+✅ **Workflow Triggered Successfully!**
+
+**Workflow Details:**
+- **Workflow**: Build and Release
+- **Run ID**: #42
+- **Parameters**:
+  - release_tag: `v1.2`
+  - release_notes: [generated content]
+  - draft: `true`
+  - prerelease: `false`
+
+**Next Steps:**
+1. 🔄 **Monitor Progress**: The workflow is now building and signing the app
+2. ⏱️ **Estimated Time**: 15-20 minutes for complete build and notarization
+3. 📦 **Draft Release**: Will be created automatically when workflow completes
+4. ✅ **Review & Publish**: Check the draft release and publish when ready
+
+**Workflow URL**: https://github.com/user/SimplyTrack/actions/runs/12345
+
+You can monitor the progress in GitHub Actions. I'll be here if you need help with any issues or want to create additional releases!
+```
+
+## Commit Analysis Examples
+
+### Example Commits Processed
+
+**Included (User-facing):**
+```
+b29ffaf - feat: add dark mode toggle in preferences
+bd32f00 - fix: resolve crash on macOS Sonoma startup  
+ab5b664 - feat: implement CSV export for time data
+d24b0ad - perf: optimize app startup time by 40%
+f72d4cb - fix: resolve timezone display in reports
+```
+
+**Excluded (Technical):**
+```
+a1b2c3d - docs: update README with new screenshots
+e4f5g6h - test: add unit tests for time calculation
+i7j8k9l - ci: update GitHub Actions workflow
+m0n1o2p - chore: update dependencies to latest versions
+q2r3s4t - refactor: restructure data models
+```
+
+### Version Detection Logic
+
+**Patch Release** (1.1.0 → 1.1.1):
+- Only `fix:` commits found
+- No new features or breaking changes
+
+**Minor Release** (1.1.0 → 1.2.0):
+- Contains `feat:` commits (new features)
+- Performance improvements
+- No breaking changes
+
+**Major Release** (1.2.0 → 2.0.0):
+- Breaking changes detected:
+  - "BREAKING CHANGE:" in commit body
+  - "!" after commit type (feat!:, fix!:)
+  - Major API changes
+
+## Error Handling Examples
+
+### No Commits Found
+```
+❌ **No New Commits**
+
+I found that there are no new commits since the last release (v1.1.0).
+
+**Possible Actions:**
+1. Check if you're on the right branch
+2. Ensure commits have been pushed to remote
+3. Consider if a release is actually needed
+
+Would you like me to check a different branch or time range?
+```
+
+### Workflow Dispatch Failure
+```
+❌ **Workflow Trigger Failed**
+
+Error: Insufficient permissions to trigger workflow
+
+**Troubleshooting Steps:**
+1. Verify GitHub MCP has `actions:write` permission
+2. Check that the workflow file exists: `.github/workflows/release.yml`
+3. Ensure you have admin/write access to the repository
+
+**Alternative**: You can manually trigger the workflow in GitHub Actions with these parameters:
+- release_tag: `v1.2`
+- release_notes: [generated content shown above]
+
+Would you like me to try again or help with manual execution?
+```
+
+## Integration Testing
+
+To test this MCP integration:
+
+1. **Verify MCP Setup**
+   ```bash
+   # Check if GitHub MCP server is running
+   # In Claude Desktop, test basic commands first
+   ```
+
+2. **Test with Small Changes**
+   ```
+   Create a patch release for testing - analyze only the last 1-2 commits and generate minimal release notes.
+   ```
+
+3. **Validate Workflow Parameters**
+   - Ensure `release.yml` accepts the expected input parameters
+   - Test workflow dispatch functionality
+   - Verify release notes formatting in GitHub
+
+4. **End-to-End Test**
+   - Use the full master prompt
+   - Review generated release notes carefully  
+   - Confirm workflow executes successfully
+   - Validate final GitHub release
+
+This example demonstrates the seamless integration between Claude Desktop, GitHub MCP, and the automated release workflow, providing a controlled and efficient release process.

--- a/MCP_RELEASE_EXAMPLE.md
+++ b/MCP_RELEASE_EXAMPLE.md
@@ -1,10 +1,10 @@
 # MCP Release Process Example
 
-This document shows an example of how the MCP-driven release process works in practice with Claude Desktop.
+Example of the MCP-driven release process with Claude Desktop.
 
-## Example Session: Creating Release v1.2.0
+## Example Session
 
-### User Input (Claude Desktop)
+### User Prompt
 ```
 I need to create a new release for SimplyTrack. Please use GitHub MCP to:
 
@@ -19,20 +19,20 @@ Create structured release notes with this EXACT format:
 ## SimplyTrack v[VERSION]
 
 ### ⚠️ Breaking Changes
-[Only if breaking changes exist]
-* Description focusing on user impact ([abc1234](commit-link))
+[Only if breaking changes exist - triggers major version]
+* Description focusing on user impact (abc1234)
 
 ### ✨ New Features
-* Feature description emphasizing user benefit ([abc1234](commit-link))
+* Feature description emphasizing user benefit (abc1234)
 
 ### 🚀 Improvements  
-* Improvement description with user impact ([abc1234](commit-link))
+* Improvement description with user impact (abc1234)
 
 ### 🐛 Bug Fixes
-* Fix description focusing on resolved user issue ([abc1234](commit-link))
+* Fix description focusing on resolved user issue (abc1234)
 
 ---
-**Release Type**: [major/minor/patch]
+**Release Type**: [major/minor]
 **Commits**: [count] 
 **Generated**: [timestamp]
 
@@ -40,8 +40,10 @@ REQUIREMENTS:
 - Focus ONLY on user-facing changes and impact
 - EXCLUDE: docs, build, ci, chore, refactor, test commits  
 - Use active voice, present tense
-- Include working GitHub commit links
-- Determine semantic version based on changes
+- Include commit short hashes (GitHub renders as links)
+- Version logic: major.minor format only (no patch)
+  - MINOR version (1.1 → 1.2): New features, bug fixes, improvements
+  - MAJOR version (1.2 → 2.0): Breaking changes detected
 - Show this preview BEFORE any actions
 
 STEP 3: SHOW PREVIEW
@@ -54,200 +56,68 @@ Use GitHub MCP to trigger the "Build and Release" workflow with:
 - draft: true
 - prerelease: false (unless specified)
 
+For pre-releases, add "prerelease: true" to STEP 4.
+For beta versions, use format like "v1.2-beta.1".
+
 Please start with Step 1 - analyze the commits and show me the preview.
 ```
 
-### Expected Claude Response
+### Claude Response
 
 ```
-I'll help you create a new release for SimplyTrack using GitHub MCP. Let me start by analyzing the commits since the last release.
-
 **STEP 1: ANALYZING COMMITS**
 
-🔍 Getting latest release tag...
-Latest release: v1.1 (released 2024-08-15)
-
-🔍 Fetching commits between v1.1 and HEAD...
-Found 12 commits to analyze
+Latest release: v1.1
+Found 8 commits to analyze
 
 **STEP 2: GENERATING RELEASE NOTES**
-
-After analyzing the commits, I've categorized the user-facing changes:
-
-📋 **RELEASE NOTES PREVIEW:**
 
 ## SimplyTrack v1.2
 
 ### ✨ New Features
 * Added dark mode support with automatic system preference detection (b29ffaf)
-* Implemented export to CSV functionality for time tracking data (bd32f00)  
-* Added keyboard shortcuts for common actions (⌘N, ⌘E, ⌘S) (ab5b664)
-
-### 🚀 Improvements
-* Improved app startup time by 40% through optimized data loading (d24b0ad)
-* Enhanced memory usage efficiency for large datasets (f72d4cb)
-* Streamlined preferences interface with better organization (a1c2d3e)
+* Implemented export to CSV functionality for time tracking data (bd32f00)
 
 ### 🐛 Bug Fixes
 * Fixed crash when opening app on macOS Sonoma (e4f5g6h)
 * Resolved timezone display issues in time reports (i7j8k9l)
-* Fixed memory leak in background time tracking (m0n1p2q)
 
 ---
 **Release Type**: minor
-**Commits**: 12
+**Commits**: 8
 **Generated**: 2024-09-07 15:30:00 UTC
 
-**STEP 3: PREVIEW CONFIRMATION**
-
-✅ **Analysis Summary:**
-- **New Features**: 3 (dark mode, CSV export, keyboard shortcuts)
-- **Improvements**: 3 (performance and UX enhancements)  
-- **Bug Fixes**: 3 (crash fixes and memory issues)
-- **Excluded**: 3 commits (docs updates, test changes, CI improvements)
-- **Suggested Version**: v1.2 (minor release due to new features)
-
-**Does this look correct? Should I proceed to trigger the release workflow with these parameters?**
+**Does this look correct? Should I proceed to trigger the release workflow?**
 
 - release_tag: `v1.2`
-- release_notes: [the content above]
 - draft: `true`
-- prerelease: `false`
-
-Please confirm to proceed with **STEP 4: TRIGGER WORKFLOW**.
 ```
 
 ### User Confirmation
 ```
-Yes, this looks perfect! Please proceed to trigger the workflow.
+Yes, proceed.
 ```
 
-### Final Claude Response
-
+### Final Response
 ```
 **STEP 4: TRIGGERING WORKFLOW**
 
-🚀 Dispatching GitHub Actions workflow...
-
-✅ **Workflow Triggered Successfully!**
-
-**Workflow Details:**
-- **Workflow**: Build and Release
-- **Run ID**: #42
-- **Parameters**:
-  - release_tag: `v1.2`
-  - release_notes: [generated content]
-  - draft: `true`
-  - prerelease: `false`
-
-**Next Steps:**
-1. 🔄 **Monitor Progress**: The workflow is now building and signing the app
-2. ⏱️ **Estimated Time**: 15-20 minutes for complete build and notarization
-3. 📦 **Draft Release**: Will be created automatically when workflow completes
-4. ✅ **Review & Publish**: Check the draft release and publish when ready
-
-**Workflow URL**: https://github.com/user/SimplyTrack/actions/runs/12345
-
-You can monitor the progress in GitHub Actions. I'll be here if you need help with any issues or want to create additional releases!
+✅ Workflow triggered successfully!
+Run ID: #42
+Monitor at: https://github.com/user/SimplyTrack/actions/runs/12345
 ```
 
-## Commit Analysis Examples
+## What Gets Included/Excluded
 
-### Example Commits Processed
+**Included:**
+- `feat:` - New features
+- `fix:` - Bug fixes  
+- `perf:` - Performance improvements
+- Other user-facing changes
 
-**Included (User-facing):**
-```
-b29ffaf - feat: add dark mode toggle in preferences
-bd32f00 - fix: resolve crash on macOS Sonoma startup  
-ab5b664 - feat: implement CSV export for time data
-d24b0ad - perf: optimize app startup time by 40%
-f72d4cb - fix: resolve timezone display in reports
-```
-
-**Excluded (Technical):**
-```
-a1b2c3d - docs: update README with new screenshots
-e4f5g6h - test: add unit tests for time calculation
-i7j8k9l - ci: update GitHub Actions workflow
-m0n1o2p - chore: update dependencies to latest versions
-q2r3s4t - refactor: restructure data models
-```
-
-### Version Detection Logic
-
-**Patch Release** (1.1.0 → 1.1.1):
-- Only `fix:` commits found
-- No new features or breaking changes
-
-**Minor Release** (1.1.0 → 1.2.0):
-- Contains `feat:` commits (new features)
-- Performance improvements
-- No breaking changes
-
-**Major Release** (1.2.0 → 2.0.0):
-- Breaking changes detected:
-  - "BREAKING CHANGE:" in commit body
-  - "!" after commit type (feat!:, fix!:)
-  - Major API changes
-
-## Error Handling Examples
-
-### No Commits Found
-```
-❌ **No New Commits**
-
-I found that there are no new commits since the last release (v1.1.0).
-
-**Possible Actions:**
-1. Check if you're on the right branch
-2. Ensure commits have been pushed to remote
-3. Consider if a release is actually needed
-
-Would you like me to check a different branch or time range?
-```
-
-### Workflow Dispatch Failure
-```
-❌ **Workflow Trigger Failed**
-
-Error: Insufficient permissions to trigger workflow
-
-**Troubleshooting Steps:**
-1. Verify GitHub MCP has `actions:write` permission
-2. Check that the workflow file exists: `.github/workflows/release.yml`
-3. Ensure you have admin/write access to the repository
-
-**Alternative**: You can manually trigger the workflow in GitHub Actions with these parameters:
-- release_tag: `v1.2`
-- release_notes: [generated content shown above]
-
-Would you like me to try again or help with manual execution?
-```
-
-## Integration Testing
-
-To test this MCP integration:
-
-1. **Verify MCP Setup**
-   ```bash
-   # Check if GitHub MCP server is running
-   # In Claude Desktop, test basic commands first
-   ```
-
-2. **Test with Small Changes**
-   ```
-   Create a patch release for testing - analyze only the last 1-2 commits and generate minimal release notes.
-   ```
-
-3. **Validate Workflow Parameters**
-   - Ensure `release.yml` accepts the expected input parameters
-   - Test workflow dispatch functionality
-   - Verify release notes formatting in GitHub
-
-4. **End-to-End Test**
-   - Use the full master prompt
-   - Review generated release notes carefully  
-   - Confirm workflow executes successfully
-   - Validate final GitHub release
-
-This example demonstrates the seamless integration between Claude Desktop, GitHub MCP, and the automated release workflow, providing a controlled and efficient release process.
+**Excluded:**
+- `docs:` - Documentation
+- `test:` - Tests
+- `ci:` - CI/CD changes
+- `chore:` - Maintenance
+- `refactor:` - Code restructuring

--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ When creating issues, please follow our simple naming convention:
 
 ## Development
 
+### Release Process
+
+Manual releases with GitHub MCP integration - see [RELEASE_PROCESS.md](RELEASE_PROCESS.md).
+
 For planned improvements and testing infrastructure, see [issue #9](https://github.com/renjfk/SimplyTrack/issues/9).
 
 ## License

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -107,4 +107,4 @@ Claude Desktop will:
 
 ---
 
-*Use the master prompt in Claude Desktop to start your next release. The entire process from commit analysis to workflow trigger will be handled automatically with human approval checkpoints.*
+*Use the master prompt in Claude Desktop to start your next release. See [MCP_RELEASE_EXAMPLE.md](MCP_RELEASE_EXAMPLE.md) for a complete example session.*

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,0 +1,110 @@
+# Manual Release Process Guide
+
+This document describes the step-by-step manual release process for SimplyTrack using GitHub MCP integration through Claude Desktop to analyze commits, generate release notes, preview in artifacts, and trigger the GitHub Actions workflow - all handled via MCP.
+
+## Overview
+
+The manual release process involves:
+
+1. **MCP-driven commit analysis** - Claude Desktop fetches and analyzes commit history
+2. **AI-generated release notes** following strict formatting conventions
+3. **Preview in artifacts** - release notes shown before any actions taken
+4. **Human review and approval** for quality control
+5. **MCP workflow dispatch** - trigger GitHub Actions via MCP
+6. **Automated build and release** - existing workflow handles the rest
+7. **User-facing focus** filtering out technical commits
+
+## Prerequisites
+
+- Claude Desktop with GitHub MCP server configured
+- GitHub repository access (MCP handles authentication)
+- Understanding of conventional commit patterns
+- Familiarity with major.minor versioning (no patch versions)
+
+## Complete MCP-Driven Release Process
+
+Use this single prompt in Claude Desktop to handle the entire release process:
+
+### Master Release Prompt for Claude Desktop
+
+```
+I need to create a new release for SimplyTrack. Please use GitHub MCP to:
+
+STEP 1: ANALYZE COMMITS
+- Get the latest release tag from the repository
+- Fetch all commits between that tag and current HEAD
+- Analyze each commit for user-facing changes
+
+STEP 2: GENERATE RELEASE NOTES
+Create structured release notes with this EXACT format:
+
+## SimplyTrack v[VERSION]
+
+### ⚠️ Breaking Changes
+[Only if breaking changes exist - triggers major version]
+* Description focusing on user impact (abc1234)
+
+### ✨ New Features
+* Feature description emphasizing user benefit (abc1234)
+
+### 🚀 Improvements  
+* Improvement description with user impact (abc1234)
+
+### 🐛 Bug Fixes
+* Fix description focusing on resolved user issue (abc1234)
+
+---
+**Release Type**: [major/minor]
+**Commits**: [count] 
+**Generated**: [timestamp]
+
+REQUIREMENTS:
+- Focus ONLY on user-facing changes and impact
+- EXCLUDE: docs, build, ci, chore, refactor, test commits  
+- Use active voice, present tense
+- Include commit short hashes (GitHub renders as links)
+- Version logic: major.minor format only (no patch)
+  - MINOR version (1.1 → 1.2): New features, bug fixes, improvements
+  - MAJOR version (1.2 → 2.0): Breaking changes detected
+- Show this preview BEFORE any actions
+
+STEP 3: SHOW PREVIEW
+Display the generated release notes and ask for approval before proceeding.
+
+STEP 4: TRIGGER WORKFLOW (after approval)
+Use GitHub MCP to trigger the "Build and Release" workflow with:
+- release_tag: v[VERSION]  
+- release_notes: [generated content]
+- draft: true
+- prerelease: false (unless specified)
+
+For pre-releases, add "prerelease: true" to STEP 4.
+For beta versions, use format like "v1.2-beta.1".
+
+Please start with Step 1 - analyze the commits and show me the preview.
+```
+
+## How It Works
+
+Claude Desktop will:
+1. **Analyze commits** since last release via GitHub MCP
+2. **Generate release notes** with proper formatting and categorization  
+3. **Show preview** and ask for approval
+4. **Trigger GitHub Actions workflow** with the release notes
+
+## Features
+
+- **Automatic filtering** of technical commits (docs, tests, CI, etc.)
+- **User-focused** release notes with clear impact descriptions
+- **Smart versioning** - minor for features/fixes, major for breaking changes
+- **Preview before action** - human approval required
+
+## Troubleshooting
+
+- **No MCP Connection**: Ensure GitHub MCP server is running
+- **Permission Denied**: Verify MCP has workflow dispatch permissions
+- **Process Fails**: Claude can retry with different parameters or suggest manual steps
+
+---
+
+*Use the master prompt in Claude Desktop to start your next release. The entire process from commit analysis to workflow trigger will be handled automatically with human approval checkpoints.*


### PR DESCRIPTION
Implements manual release process using GitHub MCP integration for quality control and human oversight.

## Changes
- Convert release workflow from tag-triggered to manual dispatch
- Add MCP-driven release process documentation
- Include example workflow with Claude Desktop integration
- Support major.minor versioning with smart detection
- Filter technical commits and focus on user-facing changes

Closes #4