### PR TITLE
feat: add clear data action for current day or week view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-- When creating PRs, always be concise with simple description and a simple list of changes and at the end mention the issue such as Closes #X or if it's a bug fix Fixes #X

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+- When creating PRs, always be concise with simple description and a simple list of changes and at the end mention the issue such as Closes #X or if it's a bug fix Fixes #X

--- a/SimplyTrack/ContentView.swift
+++ b/SimplyTrack/ContentView.swift
@@ -151,12 +151,12 @@ struct ContentView: View {
         .frame(width: 340, height: 600)
         .onChange(of: selectedDate) { _, _ in
             isViewingTodayWhenSelected = viewMode == .day && Calendar.current.isDate(selectedDate, inSameDayAs: Date())
-            MockDataGenerator.populateWithMockData(
-                for: selectedDate,
-                modelContext: modelContext,
-                config: MockDataConfig.intense,
-                sampleFromDate: { let f = DateFormatter(); f.dateFormat = "yyyy-MM-dd"; return f.date(from: "2025-09-05") ?? Date() }()
-            )
+//            MockDataGenerator.populateWithMockData(
+//                for: selectedDate,
+//                modelContext: modelContext,
+//                config: MockDataConfig.intense,
+//                sampleFromDate: { let f = DateFormatter(); f.dateFormat = "yyyy-MM-dd"; return f.date(from: "2025-09-05") ?? Date() }()
+//            )
             refreshCachedValues()
         }
         .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("PopoverWillShow"))) { _ in

--- a/SimplyTrack/Views/SettingsMenuView.swift
+++ b/SimplyTrack/Views/SettingsMenuView.swift
@@ -14,6 +14,9 @@ struct SettingsMenuView: View {
     @State private var showingUpdateAlert = false
     @State private var updateError: UpdateError?
     
+    let viewMode: ContentView.ViewMode
+    @Binding var showingClearDataConfirmation: Bool
+    
     var body: some View {
         Menu {
             Button("About") {
@@ -32,6 +35,19 @@ struct SettingsMenuView: View {
                     } else if launchAtLoginEnabled {
                         Image(systemName: "checkmark")
                     }
+                }
+            }
+            
+            Divider()
+            
+            Button(action: {
+                showingClearDataConfirmation = true
+            }) {
+                HStack {
+                    Text("Clear \(viewMode == .day ? "Day" : "Week") Data")
+                    Spacer()
+                    Image(systemName: "trash")
+                        .foregroundColor(.red)
                 }
             }
             


### PR DESCRIPTION
Add clear data functionality accessible via settings menu with context-aware button text based on current view mode.

## Changes
- Add clear data button to settings menu with red trash icon
- Implement confirmation dialog with destructive action styling
- Create unified clearData function for both day and week periods
- Integrate with existing error handling patterns

Closes #2