### PR TITLE
feat: use different database during development to avoid overwriting locally installed release instance

### DIFF
--- a/SimplyTrack/DatabaseManager.swift
+++ b/SimplyTrack/DatabaseManager.swift
@@ -1,0 +1,36 @@
+//
+//  DatabaseManager.swift
+//  SimplyTrack
+//
+//  Created by Soner Köksal on 08.09.2025.
+//
+
+import Foundation
+import SwiftData
+
+class DatabaseManager {
+    static let shared = DatabaseManager()
+    
+    private init() {}
+    
+    // Shared ModelContainer for the entire app
+    lazy var modelContainer: ModelContainer = {
+        do {
+            #if DEBUG
+            // Debug builds use a separate database file in the same directory
+            let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+            let debugURL = appSupport.appendingPathComponent("debug.store")
+            let configuration = ModelConfiguration(
+                schema: Schema([UsageSession.self, Icon.self]),
+                url: debugURL
+            )
+            return try ModelContainer(for: UsageSession.self, Icon.self, configurations: configuration)
+            #else
+            // Release builds use SwiftData's default location
+            return try ModelContainer(for: UsageSession.self, Icon.self)
+            #endif
+        } catch {
+            fatalError("Failed to create model container: \(error)")
+        }
+    }()
+}


### PR DESCRIPTION
Add separate database locations for debug and release builds to prevent development data from interfering with production data.

## Changes
- Add DatabaseManager class for centralized database configuration
- Debug builds use separate database at ~/Library/Application Support/debug.store
- Release builds use SwiftData's default location
- Debug builds show yellow icon to distinguish from release builds

Closes #19