### PR TITLE
fix: correct exportOptions.plist method from developer-id to mac-application

### DIFF
--- a/exportOptions.plist
+++ b/exportOptions.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>method</key>
-	<string>developer-id</string>
+	<string>mac-application</string>
 	<key>signingStyle</key>
 	<string>automatic</string>
 	<key>uploadBitcode</key>


### PR DESCRIPTION
Fix export method for multi-target archive compatibility.