### PR TITLE
fix: handle Safari AppleScript invalid index error when tab count changes during tracking

### DIFF
--- a/SimplyTrack/Services/Browsers/BrowserInterface.swift
+++ b/SimplyTrack/Services/Browsers/BrowserInterface.swift
@@ -60,6 +60,12 @@ class BaseBrowser: BrowserInterface {
             // Handle permission-related errors
             if scriptResult.errorCode == -1743 || scriptResult.errorCode == -1744 {
                 PermissionManager.shared.handleBrowserPermissionResult(success: false)
+            } else if scriptResult.errorCode == -1719 {
+                // Invalid index - transient race condition when tabs/windows change during polling.
+                // Silently ignore; the next polling cycle will succeed.
+                logger.debug(
+                    "Browser (\(self.displayName)) transient AppleScript error (invalid index): \(error.description)"
+                )
             } else {
                 // Log non-permission AppleScript errors using Logger
                 logger.error("Browser (\(self.displayName)) AppleScript error: \(error.description)")

--- a/SimplyTrack/Services/Browsers/SafariBrowser.swift
+++ b/SimplyTrack/Services/Browsers/SafariBrowser.swift
@@ -50,8 +50,10 @@ class SafariBrowser: BaseBrowser {
         if let error = scriptResult.error {
             // Handle permission-related errors
             if scriptResult.errorCode == -1719 {
-                // Accessibility permission denied
-                PermissionManager.shared.handleAccessibilityPermissionResult(success: false)
+                // Invalid index - transient race condition when menu items change during polling.
+                // Silently ignore; the next polling cycle will succeed.
+                logger.debug("Safari System Events transient error (invalid index): \(error.description)")
+                return false
             } else if scriptResult.errorCode == -1743 || scriptResult.errorCode == -1744 {
                 // System Events permission errors
                 PermissionManager.shared.handleSystemEventsPermissionResult(success: false)


### PR DESCRIPTION
- Handle AppleScript error -1719 (invalid index) as a transient race condition in `BaseBrowser.getCurrentURL()` instead of surfacing it as a browser communication error notification
- Fix incorrect -1719 handling in `SafariBrowser.isInPrivateBrowsingMode()` that was wrongly treated as an accessibility permission denial

Fixes #58