### PR TITLE
fix: ignore system UI in floating window detection

### DIFF
--- a/SimplyTrack/Services/TrackingService.swift
+++ b/SimplyTrack/Services/TrackingService.swift
@@ -138,15 +138,18 @@ class TrackingService {
             let activeBundleId: String
             let activeName: String
             let activeApp: NSRunningApplication
+            let activitySource: String
 
             if let floatingWindow = windowDetectionService.detectTopmostFloatingWindow(frontmostBundleId: bundleId) {
                 activeBundleId = floatingWindow.bundleIdentifier
                 activeName = floatingWindow.name
                 activeApp = floatingWindow.app
+                activitySource = "floating_overlay"
             } else {
                 activeBundleId = bundleId
                 activeName = name
                 activeApp = frontmostApp
+                activitySource = "frontmost_application"
             }
 
             // Skip system UI that shouldn't be tracked (Dock, Spotlight, Control Center, etc.)
@@ -167,6 +170,7 @@ class TrackingService {
             }
 
             // Update or create app usage session
+            logActiveAppChangeIfNeeded(identifier: activeBundleId, name: activeName, source: activitySource)
             updateAppSession(identifier: activeBundleId, name: activeName, now: now)
         }
 
@@ -213,6 +217,14 @@ class TrackingService {
             // No active session, start new one
             currentAppSession = UsageSession(type: .app, identifier: identifier, name: name, startTime: now)
         }
+    }
+
+    private func logActiveAppChangeIfNeeded(identifier: String, name: String, source: String) {
+        guard currentAppSession?.identifier != identifier else { return }
+
+        logger.log(
+            "activity_tracking decision=active_app_changed source=\(source, privacy: .public) bundle=\(identifier, privacy: .public) name=\(name, privacy: .public)"
+        )
     }
 
     private func updateWebsiteSession(identifier: String, name: String, now: Date) {

--- a/SimplyTrack/Services/WindowDetectionService.swift
+++ b/SimplyTrack/Services/WindowDetectionService.swift
@@ -8,6 +8,7 @@
 import AppKit
 import CoreGraphics
 import Foundation
+import os
 
 /// Represents a detected active window with its owning application info.
 struct DetectedWindow {
@@ -26,6 +27,8 @@ struct DetectedWindow {
 /// This handles cases like Ghostty quick terminal, Spotlight, 1Password Quick Access, etc.
 @MainActor
 class WindowDetectionService {
+
+    private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "WindowDetectionService")
 
     /// Normal window level (kCGNormalWindowLevel = 0)
     private static let normalWindowLevel = Int(CGWindowLevelForKey(.normalWindow))
@@ -113,6 +116,9 @@ class WindowDetectionService {
             if let bundleIdentifier = window.bundleIdentifier,
                 Self.ignoredBundleIds.contains(bundleIdentifier)
             {
+                logger.log(
+                    "floating_window_detection decision=skip_system_ui bundle=\(bundleIdentifier) owner=\(window.ownerName ?? "unknown") level=\(window.level) width=\(window.width) height=\(window.height)"
+                )
                 continue
             }
 
@@ -139,6 +145,10 @@ class WindowDetectionService {
                 }
 
                 let name = app.localizedName ?? window.ownerName ?? "Unknown"
+
+                logger.log(
+                    "floating_window_detection decision=accept_overlay bundle=\(window.bundleIdentifier ?? "unknown") owner=\(window.ownerName ?? "unknown") level=\(window.level) width=\(window.width) height=\(window.height)"
+                )
 
                 return DetectedWindow(
                     bundleIdentifier: window.bundleIdentifier ?? "unknown.\(window.ownerName ?? "app")",

--- a/SimplyTrack/Services/WindowDetectionService.swift
+++ b/SimplyTrack/Services/WindowDetectionService.swift
@@ -49,6 +49,15 @@ class WindowDetectionService {
     /// typically at least 200x200 points.
     private static let minimumFloatingWindowDimension: CGFloat = 200.0
 
+    /// Bundle identifiers for macOS system UI that should never override the frontmost app.
+    private static let ignoredBundleIds: Set<String> = [
+        "com.apple.dock",
+        "com.apple.loginwindow",
+        "com.apple.Spotlight",
+        "com.apple.notificationcenterui",
+        "com.apple.controlcenter",
+    ]
+
     /// Cache of PID to NSRunningApplication mappings to avoid repeated lookups.
     private var appCache: [pid_t: NSRunningApplication] = [:]
 
@@ -97,6 +106,13 @@ class WindowDetectionService {
 
             // Skip SimplyTrack's own windows
             if window.bundleIdentifier == Bundle.main.bundleIdentifier {
+                continue
+            }
+
+            // Skip macOS system UI even when it appears as a lower-level floating window.
+            if let bundleIdentifier = window.bundleIdentifier,
+                Self.ignoredBundleIds.contains(bundleIdentifier)
+            {
                 continue
             }
 

--- a/SimplyTrack/Services/WindowDetectionService.swift
+++ b/SimplyTrack/Services/WindowDetectionService.swift
@@ -117,7 +117,7 @@ class WindowDetectionService {
                 Self.ignoredBundleIds.contains(bundleIdentifier)
             {
                 logger.log(
-                    "floating_window_detection decision=skip_system_ui bundle=\(bundleIdentifier) owner=\(window.ownerName ?? "unknown") level=\(window.level) width=\(window.width) height=\(window.height)"
+                    "floating_window_detection decision=skip_system_ui bundle=\(bundleIdentifier, privacy: .public) owner=\(window.ownerName ?? "unknown", privacy: .public) level=\(window.level, privacy: .public) width=\(window.width, privacy: .public) height=\(window.height, privacy: .public)"
                 )
                 continue
             }
@@ -147,7 +147,7 @@ class WindowDetectionService {
                 let name = app.localizedName ?? window.ownerName ?? "Unknown"
 
                 logger.log(
-                    "floating_window_detection decision=accept_overlay bundle=\(window.bundleIdentifier ?? "unknown") owner=\(window.ownerName ?? "unknown") level=\(window.level) width=\(window.width) height=\(window.height)"
+                    "floating_window_detection decision=accept_overlay bundle=\(window.bundleIdentifier ?? "unknown", privacy: .public) owner=\(window.ownerName ?? "unknown", privacy: .public) level=\(window.level, privacy: .public) width=\(window.width, privacy: .public) height=\(window.height, privacy: .public)"
                 )
 
                 return DetectedWindow(

--- a/SimplyTrack/Services/WindowDetectionService.swift
+++ b/SimplyTrack/Services/WindowDetectionService.swift
@@ -8,7 +8,6 @@
 import AppKit
 import CoreGraphics
 import Foundation
-import os
 
 /// Represents a detected active window with its owning application info.
 struct DetectedWindow {
@@ -27,8 +26,6 @@ struct DetectedWindow {
 /// This handles cases like Ghostty quick terminal, Spotlight, 1Password Quick Access, etc.
 @MainActor
 class WindowDetectionService {
-
-    private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "WindowDetectionService")
 
     /// Normal window level (kCGNormalWindowLevel = 0)
     private static let normalWindowLevel = Int(CGWindowLevelForKey(.normalWindow))
@@ -116,9 +113,6 @@ class WindowDetectionService {
             if let bundleIdentifier = window.bundleIdentifier,
                 Self.ignoredBundleIds.contains(bundleIdentifier)
             {
-                logger.log(
-                    "floating_window_detection decision=skip_system_ui bundle=\(bundleIdentifier, privacy: .public) owner=\(window.ownerName ?? "unknown", privacy: .public) level=\(window.level, privacy: .public) width=\(window.width, privacy: .public) height=\(window.height, privacy: .public)"
-                )
                 continue
             }
 
@@ -145,10 +139,6 @@ class WindowDetectionService {
                 }
 
                 let name = app.localizedName ?? window.ownerName ?? "Unknown"
-
-                logger.log(
-                    "floating_window_detection decision=accept_overlay bundle=\(window.bundleIdentifier ?? "unknown", privacy: .public) owner=\(window.ownerName ?? "unknown", privacy: .public) level=\(window.level, privacy: .public) width=\(window.width, privacy: .public) height=\(window.height, privacy: .public)"
-                )
 
                 return DetectedWindow(
                     bundleIdentifier: window.bundleIdentifier ?? "unknown.\(window.ownerName ?? "app")",


### PR DESCRIPTION
## Summary
- Ignore macOS system UI bundle identifiers during floating window detection.
- Prevent Dock and similar system windows from blocking browser tracking and Automation prompts.

Fixes #64