### PR TITLE
feat: add Vivaldi website tracking support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -61,6 +61,7 @@ body:
         - Edge
         - Arc
         - Brave
+        - Vivaldi
         - Firefox
 
     validations:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ insights without the bloat.
 
 ## ✨ Features
 
-- **📊 App & Website Tracking** - Monitor time spent in applications and websites (Safari, Chrome, Edge, Arc, Brave, Firefox supported)
+- **📊 App & Website Tracking** - Monitor time spent in applications and websites (Safari, Chrome, Edge, Arc, Brave, Vivaldi, Firefox supported)
 - **📈 Visual Analytics** - Charts showing daily/weekly activity patterns
 - **🔔 Smart Notifications** - Optional AI-powered daily summary notifications with usage insights
 - **🤖 AI Integration** - Built-in MCP server for seamless integration with Claude and other AI assistants
@@ -83,7 +83,7 @@ SimplyTrack requires several macOS permissions to function properly:
 
 1. **Automation Permission**: To track browser activity
     - System Preferences → Privacy & Security → Automation
-    - Enable SimplyTrack for your browsers (Safari, Chrome, Edge, Arc, Brave, Firefox)
+    - Enable SimplyTrack for your browsers (Safari, Chrome, Edge, Arc, Brave, Vivaldi, Firefox)
 
 2. **System Events Permission**: For Safari and Firefox browser integration
     - System Preferences → Privacy & Security → Automation

--- a/SimplyTrack/Managers/PermissionManager.swift
+++ b/SimplyTrack/Managers/PermissionManager.swift
@@ -42,6 +42,7 @@ class PermissionManager: ObservableObject {
         "com.microsoft.edgemac",
         "company.thebrowser.Browser",
         "com.brave.Browser",
+        "com.vivaldi.Vivaldi",
         "org.mozilla.firefox",
     ]
 

--- a/SimplyTrack/Services/Browsers/VivaldiBrowser.swift
+++ b/SimplyTrack/Services/Browsers/VivaldiBrowser.swift
@@ -1,0 +1,52 @@
+//
+//  VivaldiBrowser.swift
+//  SimplyTrack
+//
+
+import Foundation
+
+/// Vivaldi-specific implementation of browser interface.
+/// Handles URL detection and private mode detection for Vivaldi browser.
+/// Vivaldi is Chromium-based and exposes a compatible AppleScript interface.
+class VivaldiBrowser: BaseBrowser {
+
+    init() {
+        super.init(bundleId: "com.vivaldi.Vivaldi", displayName: "Vivaldi")
+    }
+
+    /// Vivaldi-specific AppleScript for URL retrieval
+    override var currentURLScript: String {
+        return """
+                tell application id "com.vivaldi.Vivaldi"
+                    if (count of windows) > 0 then
+                        set currentTab to active tab of window 1
+                        return URL of currentTab
+                    end if
+                end tell
+            """
+    }
+
+    /// Checks if Vivaldi is currently in private mode.
+    /// Uses the 'mode' property available in Chromium-based browser AppleScript interfaces.
+    /// Note: Permissions are already verified by getCurrentURL() call, so no need to re-check.
+    /// - Returns: true if private mode is detected, false otherwise
+    override func isInPrivateBrowsingMode() -> Bool {
+        let script = """
+                tell application id "com.vivaldi.Vivaldi"
+                    if (count of windows) > 0 then
+                        return mode of window 1 is equal to "incognito"
+                    end if
+                end tell
+            """
+
+        let scriptResult = executeAppleScript(script)
+
+        guard let result = scriptResult.result,
+            let isPrivate = Bool(result.lowercased())
+        else {
+            return false
+        }
+
+        return isPrivate
+    }
+}

--- a/SimplyTrack/Services/WebTrackingService.swift
+++ b/SimplyTrack/Services/WebTrackingService.swift
@@ -3,7 +3,7 @@
 //  SimplyTrack
 //
 //  Handles browser integration, AppleScript execution, favicon fetching, and website detection
-//  Supports Safari, Chrome, Edge, Arc, Brave, and Firefox through AppleScript communication for website tracking
+//  Supports Safari, Chrome, Edge, Arc, Brave, Vivaldi, and Firefox through AppleScript communication for website tracking
 //
 
 import AppKit
@@ -62,6 +62,7 @@ class WebTrackingService {
         EdgeBrowser(),
         ArcBrowser(),
         BraveBrowser(),
+        VivaldiBrowser(),
         FirefoxBrowser(),
     ].reduce(into: [:]) { result, browser in
         result[browser.bundleId] = browser

--- a/SimplyTrack/SimplyTrack.entitlements
+++ b/SimplyTrack/SimplyTrack.entitlements
@@ -11,6 +11,7 @@
 		<string>com.microsoft.edgemac</string>
 		<string>company.thebrowser.Browser</string>
 		<string>com.brave.Browser</string>
+		<string>com.vivaldi.Vivaldi</string>
 		<string>org.mozilla.firefox</string>
 		<string>com.apple.systemevents</string>
 	</array>

--- a/SimplyTrack/Views/Settings/PrivacySettingsView.swift
+++ b/SimplyTrack/Views/Settings/PrivacySettingsView.swift
@@ -114,6 +114,16 @@ struct PrivacySettingsView: View {
                     HStack {
                         Image(systemName: "checkmark.circle.fill")
                             .foregroundColor(.green)
+                        Text("Vivaldi Private")
+                        Spacer()
+                        Text("Supported")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+
+                    HStack {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(.green)
                         Text("Firefox Private Browsing")
                         Spacer()
                         Text("Supported")


### PR DESCRIPTION
## Summary
- Add Vivaldi browser integration for website tracking and private window detection.
- Include Vivaldi in permissions, entitlements, privacy UI, README, and bug report browser options.
- Verified Vivaldi AppleScript URL and private-window mode behavior locally.

Closes #63