### PR TITLE
fix: handle Firefox address bar lookup failures

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -61,7 +61,7 @@ body:
         - Edge
         - Arc
         - Brave
-        - Firefox
+        - Firefox (experimental)
 
     validations:
       required: false

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ insights without the bloat.
 
 ## ✨ Features
 
-- **📊 App & Website Tracking** - Monitor time spent in applications and websites (Safari, Chrome, Edge, Arc, Brave, Firefox supported)
+- **📊 App & Website Tracking** - Monitor time spent in applications and websites (Safari, Chrome, Edge, Arc, Brave, Firefox experimental)
 - **📈 Visual Analytics** - Charts showing daily/weekly activity patterns
 - **🔔 Smart Notifications** - Optional AI-powered daily summary notifications with usage insights
 - **🤖 AI Integration** - Built-in MCP server for seamless integration with Claude and other AI assistants
@@ -95,7 +95,8 @@ SimplyTrack requires several macOS permissions to function properly:
 
 4. **Firefox Additional Setup**: Firefox does not expose tab URLs through its scripting interface, so
    SimplyTrack reads the address bar via the macOS Accessibility API. This requires a one-time Firefox
-   configuration change:
+   configuration change. Firefox website tracking is experimental and may stop working if Firefox changes
+   its accessibility hierarchy, if the toolbar is customized, or while the browser UI is in a transient state:
     1. Open Firefox and navigate to `about:config`
     2. Accept the risk warning if prompted
     3. Search for `accessibility.force_disabled`

--- a/SimplyTrack/Services/Browsers/FirefoxBrowser.swift
+++ b/SimplyTrack/Services/Browsers/FirefoxBrowser.swift
@@ -33,14 +33,59 @@ class FirefoxBrowser: BaseBrowser {
     override func getCurrentURL() -> String? {
         let script = """
                 tell application "System Events" to tell process "Firefox"
-                    get value of combo box 1 of group 1 of toolbar 2 of group 1 of window 1
+                    if not (exists window 1) then
+                        error "Firefox accessibility tree not available" number -2700
+                    end if
+
+                    set frontWindow to window 1
+                    if (count of UI elements of frontWindow) is 0 then
+                        error "Firefox accessibility tree not available" number -2700
+                    end if
+
+                    try
+                        set addressValue to value of combo box 1 of group 1 of toolbar 2 of group 1 of frontWindow
+                        if addressValue is not missing value and addressValue is not "" then return addressValue as text
+                    end try
+
+                    try
+                        set addressValue to value of combo box 1 of group 1 of toolbar 1 of group 1 of frontWindow
+                        if addressValue is not missing value and addressValue is not "" then return addressValue as text
+                    end try
+
+                    try
+                        set addressValue to value of combo box 1 of toolbar 1 of frontWindow
+                        if addressValue is not missing value and addressValue is not "" then return addressValue as text
+                    end try
+
+                    try
+                        set addressValue to value of combo box 1 of toolbar 2 of frontWindow
+                        if addressValue is not missing value and addressValue is not "" then return addressValue as text
+                    end try
+
+                    repeat with currentToolbar in toolbars of frontWindow
+                        try
+                            set addressValue to value of combo box 1 of currentToolbar
+                            if addressValue is not missing value and addressValue is not "" then return addressValue as text
+                        end try
+
+                        repeat with currentGroup in groups of currentToolbar
+                            try
+                                set addressValue to value of combo box 1 of currentGroup
+                                if addressValue is not missing value and addressValue is not "" then return addressValue as text
+                            end try
+                        end repeat
+                    end repeat
+
+                    return ""
                 end tell
             """
 
         let scriptResult = executeAppleScript(script)
 
         if let error = scriptResult.error {
-            if scriptResult.errorCode == -1719 || scriptResult.errorCode == -1728 {
+            let errorMessage = error["NSAppleScriptErrorMessage"] as? String ?? error.description
+
+            if errorMessage.contains("Firefox accessibility tree not available") {
                 // Accessibility tree not available - Firefox requires about:config change
                 logger.warning("Firefox accessibility tree not available. User needs to set accessibility.force_disabled to -1 in about:config.")
                 PermissionManager.shared.handleBrowserError(
@@ -48,6 +93,9 @@ class FirefoxBrowser: BaseBrowser {
                 )
             } else if scriptResult.errorCode == -1743 || scriptResult.errorCode == -1744 {
                 PermissionManager.shared.handleSystemEventsPermissionResult(success: false)
+            } else if scriptResult.errorCode == -1719 || scriptResult.errorCode == -1728 {
+                // Firefox's accessibility hierarchy can shift during navigation or between versions.
+                logger.debug("Firefox address bar unavailable in current accessibility tree: \(error.description)")
             } else {
                 logger.error("Firefox Accessibility AppleScript error: \(error.description)")
                 PermissionManager.shared.handleBrowserError("Firefox communication error: \(error.description)")


### PR DESCRIPTION
## Summary
- Add fallback Firefox address bar lookups for accessibility hierarchy changes
- Avoid showing the Firefox setup warning for transient lookup failures

Fixes #67