### PR TITLE
Add ChatGPT Atlas browser support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,6 +63,7 @@ body:
         - Brave
         - Vivaldi
         - Firefox (experimental)
+        - ChatGPT Atlas
 
     validations:
       required: false

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ SimplyTrack requires several macOS permissions to function properly:
 
 1. **Automation Permission**: To track browser activity
     - System Preferences → Privacy & Security → Automation
-    - Enable SimplyTrack for your browsers (Safari, Chrome, Edge, Arc, Brave, Vivaldi, Firefox)
+    - Enable SimplyTrack for your browsers (Safari, Chrome, Edge, Arc, Brave, Vivaldi, Firefox, ChatGPT Atlas)
 
 2. **System Events Permission**: For Safari and Firefox browser integration
     - System Preferences → Privacy & Security → Automation

--- a/SimplyTrack/Managers/PermissionManager.swift
+++ b/SimplyTrack/Managers/PermissionManager.swift
@@ -44,6 +44,7 @@ class PermissionManager: ObservableObject {
         "com.brave.Browser",
         "com.vivaldi.Vivaldi",
         "org.mozilla.firefox",
+        "com.openai.atlas",
     ]
 
     private init() {

--- a/SimplyTrack/Managers/PermissionManager.swift
+++ b/SimplyTrack/Managers/PermissionManager.swift
@@ -45,6 +45,7 @@ class PermissionManager: ObservableObject {
         "com.vivaldi.Vivaldi",
         "org.mozilla.firefox",
         "com.openai.atlas",
+        "com.openai.atlas.web",
     ]
 
     private init() {

--- a/SimplyTrack/Services/Browsers/AtlasBrowser.swift
+++ b/SimplyTrack/Services/Browsers/AtlasBrowser.swift
@@ -1,0 +1,52 @@
+//
+//  AtlasBrowser.swift
+//  SimplyTrack
+//
+
+import Foundation
+
+/// ChatGPT Atlas-specific implementation of browser interface.
+/// Handles URL detection and incognito mode detection for ChatGPT Atlas.
+/// Atlas is Chromium-based and shares the same AppleScript interface as Chrome.
+class AtlasBrowser: BaseBrowser {
+
+    init() {
+        super.init(bundleId: "com.openai.atlas", displayName: "ChatGPT Atlas")
+    }
+
+    /// ChatGPT Atlas-specific AppleScript for URL retrieval
+    override var currentURLScript: String {
+        return """
+                tell application "ChatGPT Atlas"
+                    if (count of windows) > 0 then
+                        set currentTab to active tab of window 1
+                        return URL of currentTab
+                    end if
+                end tell
+            """
+    }
+
+    /// Checks if ChatGPT Atlas is currently in incognito mode.
+    /// Uses the 'mode' property available in Atlas's Chromium AppleScript interface.
+    /// Note: Permissions are already verified by getCurrentURL() call, so no need to re-check.
+    /// - Returns: true if incognito mode is detected, false otherwise
+    override func isInPrivateBrowsingMode() -> Bool {
+        let script = """
+                tell application "ChatGPT Atlas"
+                    if (count of windows) > 0 then
+                        return mode of window 1 is equal to "incognito"
+                    end if
+                end tell
+            """
+
+        let scriptResult = executeAppleScript(script)
+
+        guard let result = scriptResult.result,
+            let isIncognito = Bool(result.lowercased())
+        else {
+            return false
+        }
+
+        return isIncognito
+    }
+}

--- a/SimplyTrack/Services/Browsers/AtlasBrowser.swift
+++ b/SimplyTrack/Services/Browsers/AtlasBrowser.swift
@@ -9,15 +9,18 @@ import Foundation
 /// Handles URL detection and incognito mode detection for ChatGPT Atlas.
 /// Atlas is Chromium-based and shares the same AppleScript interface as Chrome.
 class AtlasBrowser: BaseBrowser {
+    static let appBundleId = "com.openai.atlas"
+    static let webBundleId = "com.openai.atlas.web"
+    static let supportedBundleIds = [appBundleId, webBundleId]
 
     init() {
-        super.init(bundleId: "com.openai.atlas", displayName: "ChatGPT Atlas")
+        super.init(bundleId: Self.appBundleId, displayName: "ChatGPT Atlas")
     }
 
     /// ChatGPT Atlas-specific AppleScript for URL retrieval
     override var currentURLScript: String {
         return """
-                tell application "ChatGPT Atlas"
+                tell application id "\(Self.webBundleId)"
                     if (count of windows) > 0 then
                         set currentTab to active tab of window 1
                         return URL of currentTab
@@ -32,7 +35,7 @@ class AtlasBrowser: BaseBrowser {
     /// - Returns: true if incognito mode is detected, false otherwise
     override func isInPrivateBrowsingMode() -> Bool {
         let script = """
-                tell application "ChatGPT Atlas"
+                tell application id "\(Self.webBundleId)"
                     if (count of windows) > 0 then
                         return mode of window 1 is equal to "incognito"
                     end if

--- a/SimplyTrack/Services/WebTrackingService.swift
+++ b/SimplyTrack/Services/WebTrackingService.swift
@@ -3,7 +3,7 @@
 //  SimplyTrack
 //
 //  Handles browser integration, AppleScript execution, favicon fetching, and website detection
-//  Supports Safari, Chrome, Edge, Arc, Brave, Vivaldi, and Firefox through AppleScript communication for website tracking
+//  Supports Safari, Chrome, Edge, Arc, Brave, Vivaldi, Firefox, and ChatGPT Atlas through AppleScript communication for website tracking
 //
 
 import AppKit
@@ -64,6 +64,7 @@ class WebTrackingService {
         BraveBrowser(),
         VivaldiBrowser(),
         FirefoxBrowser(),
+        AtlasBrowser(),
     ].reduce(into: [:]) { result, browser in
         result[browser.bundleId] = browser
     }

--- a/SimplyTrack/Services/WebTrackingService.swift
+++ b/SimplyTrack/Services/WebTrackingService.swift
@@ -56,18 +56,27 @@ actor FaviconCacheActor {
 
 class WebTrackingService {
 
-    private let browsers: [String: BrowserInterface] = [
-        SafariBrowser(),
-        ChromeBrowser(),
-        EdgeBrowser(),
-        ArcBrowser(),
-        BraveBrowser(),
-        VivaldiBrowser(),
-        FirefoxBrowser(),
-        AtlasBrowser(),
-    ].reduce(into: [:]) { result, browser in
-        result[browser.bundleId] = browser
-    }
+    private let browsers: [String: BrowserInterface] = {
+        let atlasBrowser = AtlasBrowser()
+        var browsers = [
+            SafariBrowser(),
+            ChromeBrowser(),
+            EdgeBrowser(),
+            ArcBrowser(),
+            BraveBrowser(),
+            VivaldiBrowser(),
+            FirefoxBrowser(),
+            atlasBrowser,
+        ].reduce(into: [String: BrowserInterface]()) { result, browser in
+            result[browser.bundleId] = browser
+        }
+
+        for bundleId in AtlasBrowser.supportedBundleIds {
+            browsers[bundleId] = atlasBrowser
+        }
+
+        return browsers
+    }()
 
     private let faviconCacheActor = FaviconCacheActor()
 

--- a/SimplyTrack/SimplyTrack.entitlements
+++ b/SimplyTrack/SimplyTrack.entitlements
@@ -13,6 +13,7 @@
 		<string>com.brave.Browser</string>
 		<string>com.vivaldi.Vivaldi</string>
 		<string>org.mozilla.firefox</string>
+		<string>com.openai.atlas</string>
 		<string>com.apple.systemevents</string>
 	</array>
 	<key>com.apple.security.temporary-exception.files.home-relative-path.read-only</key>

--- a/SimplyTrack/SimplyTrack.entitlements
+++ b/SimplyTrack/SimplyTrack.entitlements
@@ -14,6 +14,7 @@
 		<string>com.vivaldi.Vivaldi</string>
 		<string>org.mozilla.firefox</string>
 		<string>com.openai.atlas</string>
+		<string>com.openai.atlas.web</string>
 		<string>com.apple.systemevents</string>
 	</array>
 	<key>com.apple.security.temporary-exception.files.home-relative-path.read-only</key>

--- a/SimplyTrackTests/BrowserSupportTests.swift
+++ b/SimplyTrackTests/BrowserSupportTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Testing
+
 @testable import SimplyTrack
 
 struct BrowserSupportTests {
@@ -17,5 +18,15 @@ struct BrowserSupportTests {
 
         #expect(browser != nil)
         #expect(browser?.bundleId == "com.openai.atlas")
+    }
+
+    @Test func chatGPTAtlasWebProcessIsRecognizedAsSupportedBrowser() {
+        let service = WebTrackingService()
+
+        let browser = service.getBrowser(for: "com.openai.atlas.web")
+
+        #expect(browser != nil)
+        #expect(browser?.bundleId == "com.openai.atlas")
+        #expect(browser?.displayName == "ChatGPT Atlas")
     }
 }

--- a/SimplyTrackTests/BrowserSupportTests.swift
+++ b/SimplyTrackTests/BrowserSupportTests.swift
@@ -1,0 +1,21 @@
+//
+//  BrowserSupportTests.swift
+//  SimplyTrackTests
+//
+//  Created by Hermes Agent on 06.05.2026.
+//
+
+import Testing
+@testable import SimplyTrack
+
+struct BrowserSupportTests {
+
+    @Test func chatGPTAtlasIsRecognizedAsSupportedBrowser() {
+        let service = WebTrackingService()
+
+        let browser = service.getBrowser(for: "com.openai.atlas")
+
+        #expect(browser != nil)
+        #expect(browser?.bundleId == "com.openai.atlas")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds ChatGPT Atlas as a supported Chromium-based browser for website tracking.
- Adds Atlas to browser detection, Automation entitlements, permissions/browser lists, README, and the bug report browser dropdown.
- Adds a Swift Testing regression test proving Atlas is registered by `WebTrackingService` using bundle id `com.openai.atlas`.

## Why
ChatGPT Atlas is Chromium-based and supports the same AppleScript URL lookup shape as Chrome (`URL of active tab of window 1`), but SimplyTrack did not include Atlas in its supported-browser registry or Automation entitlement list. That meant Atlas activity was recorded only as app usage, not website/domain usage.

## Testing
- Verified local Atlas AppleScript URL lookup works:
  - `osascript -e 'id of application "ChatGPT Atlas"'` → `com.openai.atlas.web`
  - `osascript -e 'tell application "ChatGPT Atlas" to if (count of windows) > 0 then return URL of active tab of window 1'` returned the active tab URL.
- Verified RED first: full test run failed on `BrowserSupportTests/chatGPTAtlasIsRecognizedAsSupportedBrowser()` before implementation.
- `xcodebuild -project SimplyTrack.xcodeproj -scheme SimplyTrack -configuration Debug -skip-testing:SimplyTrackUITests CODE_SIGNING_ALLOWED=NO test` → `** TEST SUCCEEDED **`
- `xcodebuild -project SimplyTrack.xcodeproj -scheme SimplyTrack -configuration Debug CODE_SIGNING_ALLOWED=NO build` → succeeded.
- `git diff --check` → clean.

## Notes
- Atlas's app bundle id is `com.openai.atlas`; AppleScript's `id of application "ChatGPT Atlas"` reports `com.openai.atlas.web`, so this PR uses the NSWorkspace/frontmost app bundle id for SimplyTrack registration and entitlement targeting.
