### PR TITLE
feat: add Dia browser support with incognito detection

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -62,6 +62,7 @@ body:
         - Arc
         - Brave
         - Vivaldi
+        - Dia
         - Firefox (experimental)
 
     validations:

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ SimplyTrack requires several macOS permissions to function properly:
 
 1. **Automation Permission**: To track browser activity
     - System Preferences → Privacy & Security → Automation
-    - Enable SimplyTrack for your browsers (Safari, Chrome, Edge, Arc, Brave, Vivaldi, Firefox)
+    - Enable SimplyTrack for your browsers (Safari, Chrome, Edge, Arc, Brave, Vivaldi, Dia, Firefox)
 
 2. **System Events Permission**: For Safari and Firefox browser integration
     - System Preferences → Privacy & Security → Automation

--- a/SimplyTrack/App/AppDelegate.swift
+++ b/SimplyTrack/App/AppDelegate.swift
@@ -50,6 +50,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         // Initialize all services with proper dependency injection
         initializeServices()
 
+        // Prompt for accessibility permission if not already granted
+        PermissionManager.shared.checkAccessibilityPermission()
+
         // Start services in correct order
         menuBarManager?.setupMenuBar()
         trackingService?.startTracking()

--- a/SimplyTrack/Managers/PermissionManager.swift
+++ b/SimplyTrack/Managers/PermissionManager.swift
@@ -43,6 +43,7 @@ class PermissionManager: ObservableObject {
         "company.thebrowser.Browser",
         "com.brave.Browser",
         "com.vivaldi.Vivaldi",
+        "company.thebrowser.dia",
         "org.mozilla.firefox",
     ]
 

--- a/SimplyTrack/Managers/PermissionManager.swift
+++ b/SimplyTrack/Managers/PermissionManager.swift
@@ -8,6 +8,7 @@
 import AppKit
 import ApplicationServices
 import Foundation
+import os.log
 
 /// Status of macOS system permissions required for app functionality.
 /// Used to track automation permissions needed for browser integration.
@@ -26,6 +27,8 @@ enum PermissionStatus {
 class PermissionManager: ObservableObject {
     /// Shared singleton instance for permission management
     static let shared = PermissionManager()
+
+    private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "PermissionManager")
 
     /// Current status of automation permissions for browser AppleScript access
     @Published var automationPermissionStatus: PermissionStatus = .notDetermined
@@ -87,6 +90,24 @@ class PermissionManager: ObservableObject {
             } else {
                 self.accessibilityPermissionStatus = .denied
             }
+        }
+    }
+
+    /// Checks if accessibility permissions are granted and prompts if not.
+    /// Should be called at app startup to trigger the macOS permission dialog.
+    /// Does not set `.denied` on failure — the browser error paths handle that
+    /// once the user has had a chance to respond to the system prompt.
+    func checkAccessibilityPermission() {
+        let trusted = AXIsProcessTrustedWithOptions(
+            [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
+        )
+        if trusted {
+            logger.info("Accessibility permission already granted")
+            Task { @MainActor in
+                self.accessibilityPermissionStatus = .granted
+            }
+        } else {
+            logger.warning("Accessibility permission not granted — user prompted")
         }
     }
 

--- a/SimplyTrack/Services/Browsers/DiaBrowser.swift
+++ b/SimplyTrack/Services/Browsers/DiaBrowser.swift
@@ -1,0 +1,51 @@
+//
+//  DiaBrowser.swift
+//  SimplyTrack
+//
+
+import Foundation
+
+/// Dia-specific implementation of browser interface.
+/// Handles URL detection for the Dia browser by The Browser Company.
+/// Dia exposes a custom AppleScript interface with tab and URL support.
+class DiaBrowser: BaseBrowser {
+
+    init() {
+        super.init(bundleId: "company.thebrowser.dia", displayName: "Dia")
+    }
+
+    /// Dia-specific AppleScript for URL retrieval
+    override var currentURLScript: String {
+        return """
+                tell application "Dia"
+                    if (count of windows) > 0 then
+                        return URL of active tab of window 1
+                    end if
+                end tell
+            """
+    }
+
+    /// Checks if Dia is currently in incognito mode.
+    /// Dia doesn't expose a private browsing property in its AppleScript dictionary,
+    /// so we use the accessibility API to check the window's AXIdentifier which
+    /// contains "bigIncognitoBrowserWindow" for private windows.
+    override func isInPrivateBrowsingMode() -> Bool {
+        let script = """
+                tell application "System Events"
+                    tell process "Dia"
+                        if (count of windows) > 0 then
+                            return value of attribute "AXIdentifier" of front window
+                        end if
+                    end tell
+                end tell
+            """
+
+        let scriptResult = executeAppleScript(script)
+
+        guard let identifier = scriptResult.result else {
+            return false
+        }
+
+        return identifier.contains("Incognito")
+    }
+}

--- a/SimplyTrack/Services/Browsers/DiaBrowser.swift
+++ b/SimplyTrack/Services/Browsers/DiaBrowser.swift
@@ -4,11 +4,13 @@
 //
 
 import Foundation
+import os.log
 
 /// Dia-specific implementation of browser interface.
 /// Handles URL detection for the Dia browser by The Browser Company.
 /// Dia exposes a custom AppleScript interface with tab and URL support.
 class DiaBrowser: BaseBrowser {
+    private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "DiaBrowser")
 
     init() {
         super.init(bundleId: "company.thebrowser.dia", displayName: "Dia")
@@ -41,6 +43,24 @@ class DiaBrowser: BaseBrowser {
             """
 
         let scriptResult = executeAppleScript(script)
+
+        if let error = scriptResult.error {
+            if scriptResult.errorCode == -1719 {
+                logger.debug("Dia System Events transient error (invalid index): \(error.description)")
+            } else if scriptResult.errorCode == -1743 || scriptResult.errorCode == -1744 {
+                PermissionManager.shared.handleSystemEventsPermissionResult(success: false)
+            } else if scriptResult.errorCode == -25211 {
+                PermissionManager.shared.handleAccessibilityPermissionResult(success: false)
+            } else {
+                logger.error("Dia System Events AppleScript error: \(error.description)")
+            }
+            return false
+        }
+
+        if scriptResult.result != nil {
+            PermissionManager.shared.handleSystemEventsPermissionResult(success: true)
+            PermissionManager.shared.handleAccessibilityPermissionResult(success: true)
+        }
 
         guard let identifier = scriptResult.result else {
             return false

--- a/SimplyTrack/Services/Browsers/FirefoxBrowser.swift
+++ b/SimplyTrack/Services/Browsers/FirefoxBrowser.swift
@@ -93,6 +93,8 @@ class FirefoxBrowser: BaseBrowser {
                 )
             } else if scriptResult.errorCode == -1743 || scriptResult.errorCode == -1744 {
                 PermissionManager.shared.handleSystemEventsPermissionResult(success: false)
+            } else if scriptResult.errorCode == -25211 {
+                PermissionManager.shared.handleAccessibilityPermissionResult(success: false)
             } else if scriptResult.errorCode == -1719 || scriptResult.errorCode == -1728 {
                 // Firefox's accessibility hierarchy can shift during navigation or between versions.
                 logger.debug("Firefox address bar unavailable in current accessibility tree: \(error.description)")

--- a/SimplyTrack/Services/Browsers/SafariBrowser.swift
+++ b/SimplyTrack/Services/Browsers/SafariBrowser.swift
@@ -57,6 +57,8 @@ class SafariBrowser: BaseBrowser {
             } else if scriptResult.errorCode == -1743 || scriptResult.errorCode == -1744 {
                 // System Events permission errors
                 PermissionManager.shared.handleSystemEventsPermissionResult(success: false)
+            } else if scriptResult.errorCode == -25211 {
+                PermissionManager.shared.handleAccessibilityPermissionResult(success: false)
             } else {
                 // Log non-permission System Events errors
                 logger.error("Safari System Events AppleScript error: \(error.description)")

--- a/SimplyTrack/Services/WebTrackingService.swift
+++ b/SimplyTrack/Services/WebTrackingService.swift
@@ -3,7 +3,7 @@
 //  SimplyTrack
 //
 //  Handles browser integration, AppleScript execution, favicon fetching, and website detection
-//  Supports Safari, Chrome, Edge, Arc, Brave, Vivaldi, and Firefox through AppleScript communication for website tracking
+//  Supports Safari, Chrome, Edge, Arc, Brave, Vivaldi, Dia, and Firefox through AppleScript communication for website tracking
 //
 
 import AppKit
@@ -63,6 +63,7 @@ class WebTrackingService {
         ArcBrowser(),
         BraveBrowser(),
         VivaldiBrowser(),
+        DiaBrowser(),
         FirefoxBrowser(),
     ].reduce(into: [:]) { result, browser in
         result[browser.bundleId] = browser

--- a/SimplyTrack/SimplyTrack.entitlements
+++ b/SimplyTrack/SimplyTrack.entitlements
@@ -12,6 +12,7 @@
 		<string>company.thebrowser.Browser</string>
 		<string>com.brave.Browser</string>
 		<string>com.vivaldi.Vivaldi</string>
+		<string>company.thebrowser.dia</string>
 		<string>org.mozilla.firefox</string>
 		<string>com.apple.systemevents</string>
 	</array>

--- a/SimplyTrack/Views/ContentView.swift
+++ b/SimplyTrack/Views/ContentView.swift
@@ -122,7 +122,7 @@ struct ContentView: View {
                     if permissionManager.systemEventsPermissionStatus == .denied {
                         PermissionBannerView(
                             title: "System Events Permission Required",
-                            message: "SimplyTrack needs System Events access to detect Safari private browsing. Enable it in System Preferences.",
+                            message: "SimplyTrack needs System Events access to detect Safari and Dia private browsing. Enable it in System Preferences.",
                             primaryButtonTitle: "Open System Preferences",
                             primaryAction: { permissionManager.openSystemPreferences() },
                             color: .orange
@@ -133,7 +133,7 @@ struct ContentView: View {
                     if permissionManager.accessibilityPermissionStatus == .denied {
                         PermissionBannerView(
                             title: "Accessibility Permission Required",
-                            message: "SimplyTrack needs Accessibility access to detect Safari private browsing. Enable it in System Preferences.",
+                            message: "SimplyTrack needs Accessibility access to detect Safari and Dia private browsing. Enable it in System Preferences.",
                             primaryButtonTitle: "Open System Preferences",
                             primaryAction: { permissionManager.openAccessibilityPreferences() },
                             color: .orange

--- a/SimplyTrack/Views/Settings/PrivacySettingsView.swift
+++ b/SimplyTrack/Views/Settings/PrivacySettingsView.swift
@@ -104,6 +104,16 @@ struct PrivacySettingsView: View {
                     HStack {
                         Image(systemName: "checkmark.circle.fill")
                             .foregroundColor(.green)
+                        Text("Dia Incognito")
+                        Spacer()
+                        Text("Supported")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+
+                    HStack {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(.green)
                         Text("Brave Private")
                         Spacer()
                         Text("Supported")


### PR DESCRIPTION
## Summary

- Add website tracking support for the Dia browser (by The Browser Company)
- Detect private/incognito mode using the accessibility API's `AXIdentifier` attribute
- Add Dia to the Privacy settings browser support list

## Important: New Permission Requirement

**This PR requires Accessibility access** (System Preferences → Privacy & Security → Accessibility).

Dia's AppleScript dictionary (`Dia.sdef`) does not expose an `incognito` or `mode` property on windows (unlike Arc/Chrome). The only way to detect private browsing is through the macOS Accessibility API (`System Events` → `AXIdentifier`), which requires the app to be granted Accessibility permission. Without this, incognito detection for Dia will always return `false`.

## Implementation Details

We use the System Events accessibility API to read the `AXIdentifier` of the front window:

- Regular windows: `bigBrowserWindow_<UUID>`
- Private windows: `bigIncognitoBrowserWindow_<UUID>`

## Evidence

### URL Retrieval (Dia AppleScript)

```bash
$ osascript -e 'tell application "Dia"
    if (count of windows) > 0 then
        return URL of active tab of window 1
    end if
end tell'
https://www.mozilla.org/en-US/
```

### Incognito Detection (Accessibility API)

Tested with 4 windows open (2 profiles x 2 modes):

```bash
$ osascript -e 'tell application "System Events"
    tell process "Dia"
        set allWindows to every window
        repeat with w in allWindows
            set wId to value of attribute "AXIdentifier" of w
            set wTitle to value of attribute "AXTitle" of w
            set isIncognito to wId contains "Incognito"
            log "Title: " & wTitle & " | ID: " & wId & " | Incognito: " & isIncognito
        end repeat
    end tell
end tell'

Title: Work: Mozilla - Internet… | ID: bigIncognitoBrowserWindow_A3F8D291-7C4E-4A1B-9E52-D6B1F30C84A7 | Incognito: true
Title: Work: Home - Google Driv… | ID: bigBrowserWindow_92E4B716-5D3A-48CF-B0A1-3F7E62D9C158 | Incognito: false
Title: Personal: BBC Home - Bre… | ID: bigIncognitoBrowserWindow_6D2A9F84-B13E-4720-8C9D-E5A47B28F631 | Incognito: true
Title: Personal: Comparing renj… | ID: bigBrowserWindow_F8C15E3A-2D69-4B8E-A4F6-1C93D7E0B52A | Incognito: false
```

### Confirming no native AppleScript property exists

```bash
$ osascript -e 'tell application "Dia"
    if (count of windows) > 0 then
        tell front window
            return incognito
        end tell
    end if
end tell'
execution error: The variable incognito is not defined. (-2753)
```

## Test Plan

- [x] Verify URL retrieval from Dia active tab
- [x] Verify incognito detection across multiple profiles (Work, Personal)
- [x] Verify regular windows are correctly identified as non-private
- [x] Verify private windows are correctly identified across profiles
- [x] Confirm Dia appears in Privacy settings browser support list