### PR TITLE
fix: increase test connection max_tokens to satisfy GPT-5 minimum

### DIFF
--- a/SimplyTrack/Views/Settings/AISettingsView.swift
+++ b/SimplyTrack/Views/Settings/AISettingsView.swift
@@ -309,7 +309,7 @@ struct AISettingsView: View {
                 model: aiModel,
                 messages: testMessage,
                 temperature: 0.7,
-                maxTokens: 10
+                maxTokens: 20
             )
 
             if let content = response.choices.first?.message.content {


### PR DESCRIPTION
## Summary

- GPT-5 series models (e.g., GPT-5.4) require `max_output_tokens >= 16`, but the "Test Connection" button in AI settings was sending `max_tokens: 10`
- This caused a 400 error: `Invalid 'max_output_tokens': integer below minimum value. Expected a value >= 16, but got 10 instead.`
- Increased to 20, which is compatible with both GPT-4 (min 1) and GPT-5 (min 16) model families
- The production usage in `NotificationService` (which uses `maxTokens: 300`) is unaffected

<img width="1000" height="288" alt="ScreenShot 2026-05-18 at 21 32 44@2x" src="https://github.com/user-attachments/assets/1124c63f-a008-4e5f-93e9-0bc2e3ccd020" />



## Test plan

- [x] Configure a GPT-5 series model (e.g., `gpt-5.4`) in Settings → AI and click "Test Connection" — should succeed
- [x] Configure a GPT-4 series model and click "Test Connection" — should still succeed (no regression)